### PR TITLE
FIX(ci): Use maintained base image

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM ubirch/java
+FROM amazoncorretto:8u342
 ARG GO_PIPELINE_COUNTER=manual
 ARG GO_PIPELINE_LABEL=manual
 ARG GO_PIPELINE_NAME=manual


### PR DESCRIPTION
This is part of the CVE-2022-2068 fixes.
ubirch/java has not been updated in years.
Switching to the Amazon corretto build of Java 8.

See: OPS-577